### PR TITLE
Ensure all jobs have six upgrades available

### DIFF
--- a/data/abilities/multi_shot.json
+++ b/data/abilities/multi_shot.json
@@ -1,0 +1,9 @@
+{
+    "name": "Multi-Shot",
+    "description": "Put multiple shots into the enemy for extra damage",
+    "power": 11,
+    "range_max": 4,
+    "type": "physical",
+    "ep_cost": 2,
+    "jp_cost": 140
+}

--- a/data/jobs/aetherist.json
+++ b/data/jobs/aetherist.json
@@ -12,8 +12,8 @@
     ],
     "basic_attack": "basic_attack",
     "stat_upgrades": {
-        "hp": 2,
-        "ep": 2
+        "hp": 1,
+        "ep": 1
     },
     "hp_offset": 2,
     "ep_offset": 1

--- a/data/jobs/bowman.json
+++ b/data/jobs/bowman.json
@@ -4,7 +4,8 @@
         "job_brawler_2"
     ],
     "abilities": [
-      "pin_down"
+      "pin_down",
+      "multi_shot"
     ],
     "basic_attack": "ba_pa_range",
     "stat_upgrades": {

--- a/data/jobs/brawler.json
+++ b/data/jobs/brawler.json
@@ -3,6 +3,7 @@
     "basic_attack": "ba_pa_med",
     "stat_upgrades": {
         "hp": 3,
-        "physical_attack": 3
+        "physical_attack": 2,
+        "ep": 1
     }
 }

--- a/data/jobs/ruinsmith.json
+++ b/data/jobs/ruinsmith.json
@@ -9,7 +9,6 @@
         "blast"
     ],
     "stat_upgrades": {
-        "ep": 3,
         "magical_attack": 3
     }
 }


### PR DESCRIPTION
An "upgrade" is either a stat upgrade or a new ability.

I have also given the Bowman a new "Multi Shot" ability (50% more damage for 100% more EP) instead of giving it another stat upgrade to get to six upgrades.

This finishes up #72 